### PR TITLE
Refactor to use `clap` and subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +589,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b417ae4361bca3f5de378294fc7472d3c4ed86a5ef9f49e93ae722f432aae8d2"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c90dc0f0e42c64bff177ca9d7be6fcc9ddb0f26a6e062174a61c84dd6c644d4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +638,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation"
@@ -872,6 +974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1182,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,9 +1215,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "link-cplusplus"
@@ -1114,6 +1233,12 @@ name = "linux-raw-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
@@ -1253,7 +1378,7 @@ version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1407,7 +1532,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1515,11 +1640,24 @@ version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.4",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1597,6 +1735,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
+ "clap",
  "crc32c",
  "either",
  "hex",
@@ -1644,7 +1783,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1843,7 +1982,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.37.15",
  "windows-sys 0.45.0",
 ]
 
@@ -2185,6 +2324,12 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,5 @@ atty = "0.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
+clap = {version="4.3.22", features=["derive"]}
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aws-config = { version = "0.55", default-features = false, features=["rustls"] }
+aws-config = { version = "0.55", default-features = false, features = [
+    "rustls",
+] }
 aws-sdk-s3 = "0.26"
 aws-smithy-http = "0.55"
 aws-types = "0.55"
@@ -13,7 +15,13 @@ reqwest = { version = "0.11", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 either = "1.8"
 
-tokio = { version = "1.17", features = ["macros", "sync", "fs", "io-util", "rt-multi-thread"] }
+tokio = { version = "1.17", features = [
+    "macros",
+    "sync",
+    "fs",
+    "io-util",
+    "rt-multi-thread",
+] }
 tokio-rustls = "0.24"
 
 anyhow = { version = "1.0", features = ["backtrace"] }
@@ -32,5 +40,4 @@ atty = "0.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-clap = {version="4.3.22", features=["derive"]}
-
+clap = { version = "4.3.22", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,29 @@
-# S3 scrubber
+# Neon S3 scrubber
 
-Initial presentation: https://drive.google.com/file/d/16u3qf0A17EReSXYYFxpoFqwuz3nA2wJp/view
+## Usage
 
-A project to go over S3 buckets for storage nodes, checking its contents and removing the data, not present in the console.
+### Generic Parameters
+
+#### S3
+
+Do `aws sso login --profile dev` to get the SSO access to the bucket to clean, get the SSO_ACCOUNT_ID for your profile (`cat ~/.aws/config` may help).
+
+- `SSO_ACCOUNT_ID`: Credentials id to use for accessing S3 buckets
+- `REGION`: A region where the bucket is located at.
+- `BUCKET`: Bucket name
+
+#### Console API
+
+- `CLOUD_ADMIN_API_URL`: The URL base to use for checking tenant/timeline for existence via the Cloud API.
+
+- `CLOUD_ADMIN_API_TOKEN`: The token to provide when querying the admin API. Get one on the corresponding console page, e.g. https://console.stage.neon.tech/app/settings/api-keys
+
+### Commands
+
+#### `tidy`
+
+Iterate over S3 buckets for storage nodes, checking its contents and removing the data, not present in the console.
 Node S3 data that's not removed is then further checked for discrepancies and, sometimes, validated.
-
-## Overview
 
 Storage node to check could be either pageserver or safekeeper: depending on the node type, the tool determines S3 path to check.
 For a selected S3 path, the tool lists the S3 bucket given for either tenants or both tenants and timelines — for every found entry, console API is queried: any deleted or missing in the API entity is scheduled for deletion from S3.
@@ -15,31 +33,53 @@ For pageserver, timelines' index_part.json on S3 is also checked for various dis
 
 The tool is, by default, run in "dry run" mode that does not remove anything from S3, but still performing all checks and producing the logs for the later analysis.
 
-### Current implementation details
+- NODE_KIND: safekeeper/pageserver
 
-The tool does not have any peristent state currently: instead, it creates very verbose logs, with every S3 delete request logged, every tenant/timeline id check, etc.
-Worse, any panic or early errored tasks might force the tool to exit without printing the final summary — all affected ids will still be in the logs though. The tool has retries inside it, so it's error-resistant up to some extent, and recent runs showed no traces of errors/panics.
+Which S3 key paths to construct when checking for S3 objects' existence.
 
-Instead of checking non-deleted tenants' timelines instantly, the tool attempts to create separate tasks (futures) for that,
-complicating the logic and slowing down the process, this should be fixed and done in one "task".
+- TRAVERSING_DEPTH: tenant/timeline, default: tenant
 
-The tool does uses only publicly available remote resources (S3, console) and does not access pageserver/safekeeper nodes themselves.
-Yet, its S3 set up should be prepared for running on any pageserver/safekeeper node, using node's S3 credentials, so the node API access logic could be implemented relatively simply on top.
+Whether to check and delete tenants only (by default), or also check non-deleted tenants' timelines for existence too.
+For pageserver, this would also include index_part.json validation for all non-deleted timelines, not only timeline existence check.
 
-Tool has `copied_definitions` module that contains copy-pasted storage primitives with parsing and deserializing definitions for them — that might get out of date with future storage development and should be solved either by moving the storage definitions into a separate crate (then it can be referenced via git url already) or unifying the clenup project with the storage (unclear value: extra infrastructure metadata exposure + garbage tenants and timelines in storage is a bug and should not appear normally, the work on this is ongoing: https://github.com/neondatabase/neon/issues/3889)
-Similarly S3 paths for safekeeper and pageserver are hardcoded, but not likely the structure changes in the near future.
+Command examples:
 
-Tool's way to accept parameters is through env vars. To ease future mainentance, `clap` or other proper arg parsing crates could be added, if the tool remains and gets used.
+`env SSO_ACCOUNT_ID=369495373322 REGION=eu-west-1 BUCKET=neon-dev-storage-eu-west-1 CLOUD_ADMIN_API_TOKEN=${NEON_CLOUD_ADMIN_API_STAGING_KEY} CLOUD_ADMIN_API_URL=https://console.stage.neon.tech/admin NODE_KIND=safekeeper cargo run --release -- tidy`
+
+`env SSO_ACCOUNT_ID=369495373322 REGION=us-east-2 BUCKET=neon-staging-storage-us-east-2 CLOUD_ADMIN_API_TOKEN=${NEON_CLOUD_ADMIN_API_STAGING_KEY} CLOUD_ADMIN_API_URL=https://console.stage.neon.tech/admin NODE_KIND=pageserver TRAVERSING_DEPTH=timeline cargo run --release -- tidy`
+
+When dry run stats look satisfying, use `-- --delete` to disable dry run and run the binary with deletion enabled.
+
+See these lines (and lines around) in the logs for the final stats:
+
+- `Finished listing the bucket for tenants`
+- `Finished active tenant and timeline validation`
+- `Total tenant deletion stats`
+- `Total timeline deletion stats`
+
+## Current implementation details
+
+- The tool does not have any peristent state currently: instead, it creates very verbose logs, with every S3 delete request logged, every tenant/timeline id check, etc.
+  Worse, any panic or early errored tasks might force the tool to exit without printing the final summary — all affected ids will still be in the logs though. The tool has retries inside it, so it's error-resistant up to some extent, and recent runs showed no traces of errors/panics.
+
+- Instead of checking non-deleted tenants' timelines instantly, the tool attempts to create separate tasks (futures) for that,
+  complicating the logic and slowing down the process, this should be fixed and done in one "task".
+
+- The tool does uses only publicly available remote resources (S3, console) and does not access pageserver/safekeeper nodes themselves.
+  Yet, its S3 set up should be prepared for running on any pageserver/safekeeper node, using node's S3 credentials, so the node API access logic could be implemented relatively simply on top.
+
+- Tool has `copied_definitions` module that contains copy-pasted storage primitives with parsing and deserializing definitions for them — that might get out of date with future storage development and should be solved either by moving the storage definitions into a separate crate (then it can be referenced via git url already) or unifying the clenup project with the storage (unclear value: extra infrastructure metadata exposure + garbage tenants and timelines in storage is a bug and should not appear normally, the work on this is ongoing: https://github.com/neondatabase/neon/issues/3889)
+  Similarly S3 paths for safekeeper and pageserver are hardcoded, but not likely the structure changes in the near future.
 
 ### Future concerns
 
 If the tool is left as is, a number of things might break:
 
-* `copied_definitions` might get out of date and become incompatible with the future format changes: do update these regularly or librarify/merge the codebases
+- `copied_definitions` might get out of date and become incompatible with the future format changes: do update these regularly or library-ify/merge the codebases
 
-* Console Admin API seems to be using "v1" version? V2 is already in the wild and the old version might be obsoleted eventually
+- Console Admin API seems to be using "v1" version? V2 is already in the wild and the old version might be obsoleted eventually
 
-* S3 format will change for pathes also or the layer creation/deletion logic might change on pageserver: if tool does not get obsolete, it needs to get adapted for this
+- S3 format will change for paths also or the layer creation/deletion logic might change on pageserver: if tool does not get obsolete, it needs to get adapted for this
 
 ## Cleanup procedure:
 
@@ -51,7 +91,7 @@ So first, we need to remove deleted in console tenants/timelines from pageserver
 
 First, we need to group pageservers by buckets, https://console.stage.neon.tech/admin/pageservers can be used for all env nodes, then `cat /storage/pageserver/data/pageserver.toml` on every node will show the bucket names and regions needed.
 
-* Per bucket, for every pageserver id related, find deleted tenants:
+Per bucket, for every pageserver id related, find deleted tenants:
 
 `curl -X POST "https://console.stage.neon.tech/admin/check_pageserver/{id}" -H "Accept: application/json" -H "Authorization: Bearer ${NEON_CLOUD_ADMIN_API_STAGING_KEY}" | jq`
 
@@ -61,54 +101,3 @@ Note that some tenants/timelines could be marked as deleted in console, but cons
 
 When all IDs are collected, manually go to every pageserver and detach/delete the tenant/timeline.
 In future, the cleanup tool may access pageservers directly, but now it's only console and S3 it has access to.
-
-### S3 cleanup
-
-Do `aws sso login --profile dev` to get the SSO access to the bucket to clean, get the SSO_ACCOUNT_ID for your profile (`cat ~/.aws/config` may help).
-
-Use the following env vars as parameters to run the binary, all paremeters are required unless a `default` is specified:
-
-* SSO_ACCOUNT_ID
-
-Credentials id to use for accessing S3 buckets
-
-* REGION
-
-A region where the bucket is located at.
-
-* BUCKET
-
-Bucket name
-
-* CLOUD_ADMIN_API_URL
-
-The URL base to use for checking tenant/timeline for existence via the Cloud API.
-
-* CLOUD_ADMIN_API_TOKEN
-
-The token to provide when querying the admin API.
-Get one on the corresponding console page, e.g. https://console.stage.neon.tech/app/settings/api-keys
-
-* NODE_KIND: safekeeper/pageserver
-
-Which S3 key paths to construct when checking for S3 objects' existence.
-
-* TRAVERSING_DEPTH: tenant/timeline, default: tenant
-
-Whether to check and delete tenants only (by default), or also check non-deleted tenants' timelines for existence too.
-For pageserver, this would also include index_part.json validation for all non-deleted timelines, not only timeline existence check.
-
-Command examples:
-
-`env SSO_ACCOUNT_ID=369495373322 REGION=eu-west-1 BUCKET=neon-dev-storage-eu-west-1 CLOUD_ADMIN_API_TOKEN=${NEON_CLOUD_ADMIN_API_STAGING_KEY} CLOUD_ADMIN_API_URL=https://console.stage.neon.tech/admin NODE_KIND=safekeeper cargo run --release`
-
-`env SSO_ACCOUNT_ID=369495373322 REGION=us-east-2 BUCKET=neon-staging-storage-us-east-2 CLOUD_ADMIN_API_TOKEN=${NEON_CLOUD_ADMIN_API_STAGING_KEY} CLOUD_ADMIN_API_URL=https://console.stage.neon.tech/admin NODE_KIND=pageserver TRAVERSING_DEPTH=timeline cargo run --release`
-
-When dry run stats look satisfying, use `-- --delete` to disable dry run and run the binary with deletion enabled.
-
-See these lines (and lines around) in the logs for the final stats:
-
-* `Finished listing the bucket for tenants`
-* `Finished active tenant and timeline validation`
-* `Total tenant deletion stats`
-* `Total timeline deletion stats`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Do `aws sso login --profile dev` to get the SSO access to the bucket to clean, g
 
 #### `tidy`
 
-Iterate over S3 buckets for storage nodes, checking its contents and removing the data, not present in the console. Node S3 data that's not removed is then further checked for discrepancies and, sometimes, validated.
+Iterate over S3 buckets for storage nodes, checking their contents and removing the data not present in the console. Node S3 data that's not removed is then further checked for discrepancies and, sometimes, validated.
 
 Unless the global `--delete` argument is provided, this command only dry-runs and logs
 what it would have deleted.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Neon S3 scrubber
 
+This tool directly accesses the S3 buckets used by the Neon `pageserver`
+and `safekeeper`, and does housekeeping such as cleaning up objects for tenants & timelines that no longer exist.
+
 ## Usage
 
 ### Generic Parameters
@@ -85,9 +88,7 @@ If the tool is left as is, a number of things might break:
 
 ### Pageserver preparations
 
-If S3 state is altered first manually, pageserver in-memory state will contain wrong data about S3 state, and tenants/timelines may get recreated on S3 (due to any layer upload due to compaction, pageserver restart, etc.)
-
-So first, we need to remove deleted in console tenants/timelines from pageservers.
+If S3 state is altered first manually, pageserver in-memory state will contain wrong data about S3 state, and tenants/timelines may get recreated on S3 (due to any layer upload due to compaction, pageserver restart, etc.). So before proceeding, for tenants/timelines which are already deleted in the console, we must remove these from pageservers.
 
 First, we need to group pageservers by buckets, https://console.stage.neon.tech/admin/pageservers can be used for all env nodes, then `cat /storage/pageserver/data/pageserver.toml` on every node will show the bucket names and regions needed.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod delete_batch_producer;
 mod s3_deletion;
 
 use std::env;
+use std::fmt::Display;
 use std::time::Duration;
 
 use aws_config::environment::EnvironmentVariableCredentialsProvider;
@@ -31,10 +32,19 @@ pub struct S3Target {
     pub delimiter: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TraversingDepth {
     Tenant,
     Timeline,
+}
+
+impl Display for TraversingDepth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Tenant => "tenant",
+            Self::Timeline => "timeline",
+        })
+    }
 }
 
 impl S3Target {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct Cli {
     delete: bool,
 }
 
-#[derive(ValueEnum, Clone, Copy)]
+#[derive(ValueEnum, Clone, Copy, Eq, PartialEq)]
 enum NodeKind {
     Safekeeper,
     Pageserver,
@@ -203,7 +203,7 @@ async fn tidy(
         batch_producer_stats.timelines_checked()
     );
 
-    if !matches!(node_kind, NodeKind::Pageserver) {
+    if node_kind == NodeKind::Pageserver {
         info!("node_kind != pageserver, finish without performing validation step");
         return Ok(());
     }

--- a/src/s3_deletion.rs
+++ b/src/s3_deletion.rs
@@ -258,8 +258,7 @@ where
     for &id_to_delete in batched_ids {
         let mut continuation_token = None;
         let mut subtargets = vec![target_producer(s3_target, id_to_delete)];
-        while !subtargets.is_empty() {
-            let current_target = subtargets.pop().expect("Subtargets is not empty");
+        while let Some(current_target) = subtargets.pop() {
             loop {
                 let fetch_response = list_objects_with_retries(
                     s3_client,


### PR DESCRIPTION
Initially this is just the existing functionality but in a `tidy` subcommand.  The refactor enables adding more other commands.